### PR TITLE
Potential fix for code scanning alert no. 1: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,12 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath))
+            {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Potential fix for [https://github.com/jjdun30-tech/skills-secure-repository-supply-chain/security/code-scanning/1](https://github.com/jjdun30-tech/skills-secure-repository-supply-chain/security/code-scanning/1)

To fix the vulnerability, sanitize and check the resolved extraction path as recommended in the background:  
- Use `Path.GetFullPath(Path.Combine(destDirectory, entry.FullName))` to resolve any traversal attempts in the extracted path.
- Use `Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar)` to get the fully resolved extraction root directory (ensuring the separator for exact matching).
- Check that the candidate extraction file path starts with the resolved destination directory path (`StartsWith`). If the check fails, throw an exception or skip extraction.
- All these changes should be applied within the `WriteToDirectory` method in the file `code/src/Attendee/Attendee.cs`.

No new methods or imports are necessary because the required types (`Path`) are already imported.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
